### PR TITLE
Make extension translatable and add German translation

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
   "name": "Advanced Volume Control",
   "description": "Control volume of multiple sound interfaces",
   "uuid": "advancedvolumecontrol@mark.johnson.ubuntu.com",
+  "gettext-domain": "my-indicator-extension",
   "url": "https://github.com/marxjohnson/advancedvolumecontrol",
   "shell-version": [
     "42",

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,26 @@
+# German translation of the Advanced Volume Control GNOME Extension.
+# Copyright (C) 2023 Mark Johnson
+# This file is distributed under the same license as the Advanced Volume Control package.
+#
+# Philipp Kiemle <philipp.kiemle@gmail.com>, 2023.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Advanced Volume Control\n"
+"Report-Msgid-Bugs-To: https://github.com/marxjohnson/advancedvolumecontrol/"
+"issues\n"
+"POT-Creation-Date: 2023-07-24 22:45+0200\n"
+"PO-Revision-Date: 2023-07-24 22:45+0200\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: extension.js:71
+msgid "Advanced volume control"
+msgstr "Erweiterter Lautstärkeregler"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Advanced Volume Control package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Advanced Volume Control\n"
+"Report-Msgid-Bugs-To: https://github.com/marxjohnson/advancedvolumecontrol/"
+"issues\n"
+"POT-Creation-Date: 2023-07-24 22:45+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: extension.js:71
+msgid "Advanced volume control"
+msgstr ""

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Updates all translation-related files.
+
+# Search for translatable strings and put them in po/messages.po
+xgettext --from-code=UTF-8 \
+         --add-comments="Translators" \
+         --package-name="Advanced Volume Control" \
+         --msgid-bugs-address="https://github.com/marxjohnson/advancedvolumecontrol/issues" \
+         -o po/messages.pot -- *.js
+
+# Check if any translations have changed and need an update
+for file in po/*.po
+do
+    echo -n "Updating $(basename "$file" .po)"
+    msgmerge -U "$file" po/messages.pot
+
+    if grep --silent "#, fuzzy" "$file"; then
+        fuzzy+=("$(basename "$file" .po)")
+    fi
+done
+
+if [[ -v fuzzy ]]; then
+    echo "WARNING: The following translations have fuzzy strings and need an update: ${fuzzy[*]}"
+fi


### PR DESCRIPTION
I know - there is only one string (and I couldn't even find it in the UI). But I wanted to do this anyway, since I had the time and maybe you would like to add some more strings in the future ;)

`update-translations.sh` does what it says, as a little helper script.

BTW: I noticed that you manually zip the extension in `package.sh` Did you know about the `gnome-extension pack` command? May be worth a look!